### PR TITLE
feat: add mapper for project form

### DIFF
--- a/Backend/main/src/main/java/dev/bengi/main/modules/projects/controller/ProjectController.java
+++ b/Backend/main/src/main/java/dev/bengi/main/modules/projects/controller/ProjectController.java
@@ -7,6 +7,7 @@ import dev.bengi.main.modules.projects.dto.ProjectResponseDto;
 import dev.bengi.main.modules.projects.dto.ProjectUpdateRequestDto;
 import dev.bengi.main.modules.projects.dto.ProjectCreateForm;
 import dev.bengi.main.modules.projects.dto.ProjectUpdateForm;
+import dev.bengi.main.modules.projects.dto.ProjectFormMapper;
 import dev.bengi.main.modules.projects.service.ProjectService;
 import dev.bengi.main.modules.projects.dto.ProjectMembersRequestDto;
 import lombok.extern.slf4j.Slf4j;
@@ -28,32 +29,14 @@ public class ProjectController {
 
     private final ProjectService projectService;
     private final PaginationService paginationService;
+    private final ProjectFormMapper projectFormMapper;
 
     @PostMapping
     @PreAuthorize("hasRole('ADMIN')")
     public Mono<ResponseEntity<ProjectResponseDto>> create(@ModelAttribute ProjectCreateForm form) {
-        
-        log.info("=== PROJECT CREATE REQUEST ===");
-        log.info("Name: {}", form.getName());
-        log.info("Description: {}", form.getDescription());
-        log.info("Start Date: {}", form.getStartDate());
-        log.info("End Date: {}", form.getEndDate());
-        log.info("Active: {}", form.isActive());
-        log.info("Members: {}", form.getMembers());
-        
-        ProjectRequestDto req = new ProjectRequestDto(
-            form.getName(),
-            form.getDescription(),
-            form.getStartDate() != null && !form.getStartDate().isEmpty() ? 
-                java.time.LocalDateTime.parse(form.getStartDate() + "T00:00:00") : null,
-            form.getEndDate() != null && !form.getEndDate().isEmpty() ? 
-                java.time.LocalDateTime.parse(form.getEndDate() + "T00:00:00") : null,
-            form.isActive(),
-            form.getMembers() != null ? form.getMembers().stream().map(Long::parseLong).toList() : java.util.List.of()
-        );
-        
-        log.info("Created ProjectRequestDto: {}", req);
-        
+        ProjectRequestDto req = projectFormMapper.toRequest(form);
+        log.info("Project create request: {}", req);
+
         return projectService.create(req)
                 .map(d -> {
                     log.info("Project created successfully: {}", d);
@@ -65,19 +48,9 @@ public class ProjectController {
     @PreAuthorize("hasRole('ADMIN')")
     public Mono<ResponseEntity<ProjectResponseDto>> update(@PathVariable Long id,
                                                            @ModelAttribute ProjectUpdateForm form) {
-        
-        ProjectUpdateRequestDto req = new ProjectUpdateRequestDto(
-            form.getName(),
-            form.getDescription(),
-            form.getStartDate() != null && !form.getStartDate().isEmpty() ? 
-                java.time.LocalDateTime.parse(form.getStartDate() + "T00:00:00") : null,
-            form.getEndDate() != null && !form.getEndDate().isEmpty() ? 
-                java.time.LocalDateTime.parse(form.getEndDate() + "T00:00:00") : null,
-            form.isActive(),
-            form.getMembers() != null ? form.getMembers().stream().map(Long::parseLong).toList() : java.util.List.of(),
-            form.getExistingMembers() != null ? form.getExistingMembers().stream().map(Long::parseLong).toList() : java.util.List.of()
-        );
-        
+        ProjectUpdateRequestDto req = projectFormMapper.toUpdateRequest(form);
+        log.info("Project update request: {}", req);
+
         return projectService.update(id, req)
                 .map(ResponseEntity::ok);
     }

--- a/Backend/main/src/main/java/dev/bengi/main/modules/projects/dto/ProjectFormMapper.java
+++ b/Backend/main/src/main/java/dev/bengi/main/modules/projects/dto/ProjectFormMapper.java
@@ -1,0 +1,30 @@
+package dev.bengi.main.modules.projects.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface ProjectFormMapper {
+
+    @Mapping(target = "startDate", expression = "java(parseDate(form.getStartDate()))")
+    @Mapping(target = "endDate", expression = "java(parseDate(form.getEndDate()))")
+    @Mapping(target = "members", expression = "java(parseMembers(form.getMembers()))")
+    ProjectRequestDto toRequest(ProjectCreateForm form);
+
+    @Mapping(target = "startDate", expression = "java(parseDate(form.getStartDate()))")
+    @Mapping(target = "endDate", expression = "java(parseDate(form.getEndDate()))")
+    @Mapping(target = "members", expression = "java(parseMembers(form.getMembers()))")
+    @Mapping(target = "existingMembers", expression = "java(parseMembers(form.getExistingMembers()))")
+    ProjectUpdateRequestDto toUpdateRequest(ProjectUpdateForm form);
+
+    default LocalDateTime parseDate(String date) {
+        return (date != null && !date.isEmpty()) ? LocalDateTime.parse(date + "T00:00:00") : null;
+        }
+
+    default List<Long> parseMembers(List<String> members) {
+        return members != null ? members.stream().map(Long::parseLong).toList() : List.of();
+        }
+}


### PR DESCRIPTION
## Summary
- add MapStruct mapper to convert project forms into request DTOs
- use mapper in `ProjectController` for create and update
- replace verbose field logs with structured DTO logging

## Testing
- `gradle test` *(fails: Task :compileJava FAILED)*

------
https://chatgpt.com/codex/tasks/task_e_68b69847c7908324b6645ddeac7af952