### PR TITLE
Refactor auth hook into store, service, and utilities

### DIFF
--- a/frontend/admin/app/(app)/dashboard/_components/DashboardStats.tsx
+++ b/frontend/admin/app/(app)/dashboard/_components/DashboardStats.tsx
@@ -15,7 +15,7 @@ import Link from 'next/link';
 import { useEffect, useState } from 'react';
 
 import { apiRequest } from '@/utils/api';
-import useAuthStore from '@/hooks/useAuth';
+import useAuthStore from '@/stores/authStore';
 
 interface StatData {
   totalUsers?: number;

--- a/frontend/admin/app/(auth)/login/page.tsx
+++ b/frontend/admin/app/(auth)/login/page.tsx
@@ -22,7 +22,7 @@ import {
   KeyRound,
 } from 'lucide-react';
 
-import useAuthStore from '@/hooks/useAuth';
+import useAuthStore from '@/stores/authStore';
 
 export default function LoginPage() {
   const { signIn, loading, error, clearError } = useAuthStore();

--- a/frontend/admin/app/(auth)/logout/page.tsx
+++ b/frontend/admin/app/(auth)/logout/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 
-import useAuthStore from '@/hooks/useAuth';
+import useAuthStore from '@/stores/authStore';
 
 export default function LogoutPage() {
   const { signOut } = useAuthStore();

--- a/frontend/admin/contexts/AuthContext.tsx
+++ b/frontend/admin/contexts/AuthContext.tsx
@@ -5,7 +5,7 @@ import type { AuthContextType } from '@/types/auth';
 import { createContext, useContext, useEffect, ReactNode, useRef } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
 
-import useAuthStore from '@/hooks/useAuth';
+import useAuthStore from '@/stores/authStore';
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 

--- a/frontend/admin/hooks/useDashboard.ts
+++ b/frontend/admin/hooks/useDashboard.ts
@@ -13,7 +13,7 @@ import { addToast } from '@heroui/react';
 
 import { apiRequest } from '@/utils/api';
 import { getToken } from '@/utils/storage';
-import useAuthStore from '@/hooks/useAuth';
+import useAuthStore from '@/stores/authStore';
 
 // Mock data for fallback when API fails
 const mockDashboardData: DashboardStats = {

--- a/frontend/admin/services/authService.ts
+++ b/frontend/admin/services/authService.ts
@@ -1,0 +1,30 @@
+import type {
+  JwtResponse,
+  LoginRequest,
+  TokenValidationResponse,
+} from '@/types/auth';
+
+import { api } from '@/libs/apiClient';
+
+export function login(request: LoginRequest) {
+  return api.post<JwtResponse>('/api/auth/login', request, { auth: false });
+}
+
+export function logout() {
+  return api.post<void>('/api/auth/logout');
+}
+
+export function refresh(refreshToken: string) {
+  return api.post<JwtResponse>(
+    '/api/auth/refresh-token',
+    {},
+    {
+      headers: { 'Refresh-Token': refreshToken },
+      auth: false,
+    },
+  );
+}
+
+export function validate() {
+  return api.get<TokenValidationResponse>('/api/auth/validate');
+}

--- a/frontend/admin/utils/token.ts
+++ b/frontend/admin/utils/token.ts
@@ -1,0 +1,36 @@
+/**
+ * Helper to check if JWT is expired
+ */
+export function isTokenExpired(token: string): boolean {
+  try {
+    const [, payloadBase64] = token.split('.');
+    const payload = JSON.parse(atob(payloadBase64));
+    const exp = payload.exp;
+    const currentTime = Math.floor(Date.now() / 1000);
+
+    return exp < currentTime;
+  } catch (err) {
+    console.warn('Error parsing token:', err);
+
+    return true;
+  }
+}
+
+/**
+ * Helper to check if JWT will expire soon (within 5 minutes)
+ */
+export function isTokenExpiringSoon(token: string): boolean {
+  try {
+    const [, payloadBase64] = token.split('.');
+    const payload = JSON.parse(atob(payloadBase64));
+    const exp = payload.exp;
+    const currentTime = Math.floor(Date.now() / 1000);
+    const fiveMinutes = 5 * 60;
+
+    return exp < currentTime + fiveMinutes;
+  } catch (err) {
+    console.warn('Error parsing token:', err);
+
+    return true;
+  }
+}


### PR DESCRIPTION
## Summary
- Split monolithic `useAuth` into dedicated modules for store, token helpers, and service API calls
- Update AuthContext and affected components to reference the new auth store

## Testing
- `npx eslint stores/authStore.ts utils/token.ts services/authService.ts hooks/useDashboard.ts contexts/AuthContext.tsx app/(app)/dashboard/_components/DashboardStats.tsx app/(auth)/login/page.tsx app/(auth)/logout/page.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b6984fc7f0832490cbbccf90b0d020